### PR TITLE
#30: Single template class

### DIFF
--- a/resources/src/config.php
+++ b/resources/src/config.php
@@ -5,6 +5,7 @@ namespace src;
 class ProjectConfig
 {
     public $config;
+    public $pageDict;
     public function __construct()
     {
         $creds = json_decode(file_get_contents($_SERVER["DOCUMENT_ROOT"] . "/../resources/dbcreds.json"), true);
@@ -29,6 +30,25 @@ class ProjectConfig
                 "css" =>  "/asset/css",
                 "js" => "/asset/js"
             )
+        );
+        // a Dictonary of pages to make code/mentioning them more easy!
+        $this->pageDict = array(
+            "aboutus" => "About Us",
+            "ad_issued" => "Edit Book",
+            "addbook" => "Add Book",
+            "admindash" => "Dashboard",
+            "contactus" => "Contact Us",
+            "displaynew" => "New Collection",
+            "editbook" => "Edit Book",
+            "edituserlist" => "Edit User",
+            "index" => "Home",
+            "listbookedit" => "Edit Book",
+            "login" => "Login",
+            "logout" => "Logout",
+            "register" => "Sign Up",
+            "searchbook" => "Search Book",
+            "userdash" => "Dashboard",
+            "test" => "LAB"
         );
     }
     public function dispConfig()

--- a/resources/src/sessionCookie.php
+++ b/resources/src/sessionCookie.php
@@ -7,6 +7,7 @@ require $_SERVER['DOCUMENT_ROOT'] . '/../vendor/autoload.php';
 use src\Redirect;
 use src\Connection;
 use template\Menu;
+
 class SessionCookie
 {
     public $redirect;
@@ -46,6 +47,12 @@ class SessionCookie
     {
         if (!isset($_SESSION['uid'])) $this->redirect->phploc('index.php');
     }
+    public function loginAccess()
+    {
+        if (isset($_SESSION["logged_in"])) return true;
+        else return false;
+    }
+    // Functions not being used as of now
     public function adminCheck()
     {
         if ($_SESSION["admin"] == "user") {
@@ -70,7 +77,7 @@ class SessionCookie
             $this->redirect->phploc('index.php');
         }
     }
-    
+
     public function login_check()
     {
         if (isset($_SESSION["logged_in"])) {

--- a/resources/template/menu.php
+++ b/resources/template/menu.php
@@ -134,4 +134,11 @@ class Menu
         $this->mobile_nav();
         $this->sidebar();
     }
+    public function render_headNav()
+    {
+        $this->render_header();
+        $this->mobile_nav();
+        $this->sidebar();
+    }
+
 }

--- a/resources/template/pageTemplate.php
+++ b/resources/template/pageTemplate.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace template;
+
+require $_SERVER['DOCUMENT_ROOT'] . '/../vendor/autoload.php';
+
+use src\ProjectConfig;
+use src\SessionCookie;
+use template\Menu;
+
+class Page
+{
+    public $config;
+    public $session;
+    public $head;
+    public $menu;
+    public $content;
+    public $foot;
+    public function __construct()
+    {
+        $this->config = new ProjectConfig;
+        $this->session = new SessionCookie;
+        $title = $this->config->pageDict[basename($_SERVER['PHP_SELF'], '.php')];
+
+        $this->head = "
+        <!DOCTYPE html>
+        <html lang='en'>
+        <meta name='Description' content='Bookhive - A Digital Library Management System'>
+        <meta name='viewport' content='width=device-width, initial-scale=1'>
+        <title>" . $title . "</title>
+        <link rel='stylesheet' href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.12.1/css/all.min.css'>
+        <link rel='stylesheet' href='" . $this->config->config["paths"]["css"] . "/main.css'>
+        </head>
+        <body>
+        ";
+
+        if ($this->session->loginAccess()) {
+            $this->menu = new Menu(basename(__FILE__), $_SESSION["admin"], $_SESSION["uname"]);
+        } else {
+            $this->menu = new Menu(basename(__FILE__));
+        }
+
+        $this->foot = "
+        <script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js' charset='utf-8'></script>
+        <script src='" . $this->config->config["paths"]["js"] . "/main.js'></script>
+        </body>
+        </html>
+        ";
+    }
+    public function constructPage($content)
+    {
+        echo $this->head;
+        $this->menu->render_headNav();
+        echo $content;
+        echo $this->foot;
+    }
+}


### PR DESCRIPTION
This is a single template class which can be used in pages to write less boiler code.
issue: https://github.com/JayKandari/bookhive/issues/30

Sample code: (about us page with far less code! I have only removed the head and foot rest of them can be refactored more but not now)

```php

<?php
require $_SERVER['DOCUMENT_ROOT'] . '/../vendor/autoload.php';
use template\Page;
$new = new Page;
$var1 = "Hello Alphons";
$content = <<<EOT
<h1> Hi ${var1} </h1>
<div class="main_content">
    <div class="row">
  <div class="column">
    <div class="card">
    <img src="../asset/images/aastha.jpg" alt="Avatar" style="width:100%">
      <h3>Aastha Shrivastava</h3>
      <p>Drupal Frontend Intern</p>
    </div>
  </div>
  <div class="column">
    <div class="card">
    <img src="../asset/images/pragati.jpeg" alt="Avatar" style="width:100%">
      <h3>Pragati Kanade</h3>
      <p>Drupal Frontend Intern</p>
    </div>
  </div> 
  </div>
  
  <div class="row">
  <div class="column">
    <div class="card">
    <img src="../asset/images/a.jpg" alt="Avatar" style="width:100%">
      <h3>Anjali Rathod</h3>
      <p>Drupal Frontend Intern</p>
    </div>
  </div>
  
  <div class="column">
    <div class="card">
    <img src="../asset/images/alphonse.jpg" alt="Avatar" style="width:100%">
      <h3>Alphons Jaimon</h3>
      <p>Drupal Full Stack Intern</p>
    </div>
  </div>
</div>
</div>
EOT;
$new->constructPage($content);

```

**PLUS** I added a dictionary in config!
This dict will contain all the public page filenames as key and title as value.
This looks a lot more organized. What do you think @shriaas2898 @pragzii3896 @anjali-rathod @JayKandari @guptahemant
**NOTE: Any new pages should be listed here with title.**

Related doc:
https://www.php.net/manual/en/language.types.string.php#language.types.string.syntax.heredoc 