### PR TITLE
Added htaccess

### DIFF
--- a/public-html/.htaccess
+++ b/public-html/.htaccess
@@ -1,0 +1,4 @@
+RewriteEngine on
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_FILENAME}\.php -f
+RewriteRule ^(.*)$ $1.php [NC,L] 


### PR DESCRIPTION
Added htacces to eliminate .php extension in the url
eg.
BEFORE ->
`bookhive.io/index.php` was accessible
but
`bookhive.io/index` was not accessible

NOW with minor htaccess edit
Both `bookhive.io/index.php` and `bookhive.io/index` are accessible

Related doc: https://www.plothost.com/kb/how-to-remove-php-html-extensions-with-htaccess/