### PR TITLE
Removed repeatation of `session_start()` line

### DIFF
--- a/public-html/edituserlist.php
+++ b/public-html/edituserlist.php
@@ -1,5 +1,4 @@
 <?php
-session_start();
 require $_SERVER['DOCUMENT_ROOT'] . '/../vendor/autoload.php';
 
 use src\user;

--- a/public-html/register.php
+++ b/public-html/register.php
@@ -1,5 +1,4 @@
 <?php
-session_start();
 require $_SERVER['DOCUMENT_ROOT'] . '/../vendor/autoload.php';
 
 use src\user;

--- a/public-html/userdash.php
+++ b/public-html/userdash.php
@@ -1,5 +1,4 @@
 <?php
-session_start();
 require $_SERVER['DOCUMENT_ROOT'] . '/../vendor/autoload.php';
 
 use src\ProjectConfig;


### PR DESCRIPTION
Removed repeatation of `session_start()` line in various pages not required cause after initialization of session class session_start automatically happens!